### PR TITLE
Mock_ioctl: use varargs

### DIFF
--- a/test/mock_ioctl.c
+++ b/test/mock_ioctl.c
@@ -1,17 +1,21 @@
 #define _GNU_SOURCE
 
 #include <dlfcn.h>
+#include <stdarg.h>
 #include <stdlib.h>
 #include <stdio.h>
-#include <asm-generic/ioctls.h>
-#include <asm-generic/termios.h>
+#include <sys/ioctl.h>
 
 typedef int (*ioctl_t)(int, unsigned long, char*);
 
 static ioctl_t real_ioctl = NULL;
 
-int ioctl(int fd, unsigned long request, char* argp)
+int ioctl(int fd, unsigned long request, ...)
 {
+	va_list ap;
+	va_start(ap, request);
+	char *argp = va_arg(ap, char *);
+	int ret = 0;
 	if (real_ioctl == NULL) {
 		real_ioctl = (ioctl_t) dlsym(RTLD_NEXT, "ioctl");
 	}
@@ -19,13 +23,16 @@ int ioctl(int fd, unsigned long request, char* argp)
 		char* p_rows = getenv("FAKE_ROWS");
 		char* p_cols = getenv("FAKE_COLS");
 		if (*p_rows == '\0' || *p_cols == '\0') {
-			return -1;
+			ret = -1;
+		} else {
+			struct winsize *pws = (struct winsize *) argp;
+			pws->ws_row = atoi(p_rows);
+			pws->ws_col = atoi(p_cols);
+			ret = 0;
 		}
-		struct winsize *pws = (struct winsize *) argp;
-		pws->ws_row = atoi(p_rows);
-		pws->ws_col = atoi(p_cols);
-		return 0;
 	} else {
-		return real_ioctl(fd, request, argp);
+		ret = real_ioctl(fd, request, argp);
 	}
+	va_end(ap);
+	return ret;
 }


### PR DESCRIPTION
The previous version would include system-specific headers to have the
value of ioctls without a conflicting type for the `ioctl` function.

Instead this uses a compatible type and deals with varargs manually.