### PR TITLE
Release v0.1.4

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,13 @@
+v0.1.4
+------
+
+*2019-05-24*
+
+Build system:
+
+- Upgrade to opam 2
+- Build with dune
+
 v0.1.3
 ------
 

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,4 @@
-Copyright (c) 2018, Cryptosense SA
+Copyright (c) 2019, Cryptosense SA
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/terminal_size.opam
+++ b/terminal_size.opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-maintainer: "Etienne Millon <etienne@cryptosense.com>"
+maintainer: "Cryptosense <opensource@cryptosense.com>"
 authors: "Etienne Millon <etienne@cryptosense.com>"
 homepage: "https://github.com/cryptosense/terminal_size"
 bug-reports: "https://github.com/cryptosense/terminal_size/issues"


### PR DESCRIPTION
This MR updates the maintainer to the new opensource@cryptosense.com address, and prepares to cut a new release.

The new release will use the new `dune` build process, and so the library stubs will be installed in the correct place for `dune utop` to work.