### PR TITLE
Bump ocaml and dune requirements

### DIFF
--- a/terminal_size.opam
+++ b/terminal_size.opam
@@ -14,8 +14,8 @@ run-test: [
 ]
 depends: [
   "alcotest" {with-test}
-  "dune" {build & >= "1.2.0"}
-  "ocaml" {>= "4.01.0"}
+  "dune" {build & >= "1.10.0"}
+  "ocaml" {>= "4.02.0"}
 ]
 synopsis: "Get the dimensions of the terminal"
 description: """


### PR DESCRIPTION
Since we now use dune language version `1.10` to get the mac tests working, bump the required dune version in the `opam` version to prevent build errors.