### PR TITLE
Support alpine

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,9 @@ script: bash ./.travis-docker.sh
 env:
   global:
     - PACKAGE=terminal_size
-    - DISTRO=debian-stable
   matrix:
-    - OCAML_VERSION=4.04
-    - OCAML_VERSION=4.05
-    - OCAML_VERSION=4.06
-    - OCAML_VERSION=4.07
+    - OCAML_VERSION=4.04 DISTRO=debian-stable
+    - OCAML_VERSION=4.05 DISTRO=debian-stable
+    - OCAML_VERSION=4.06 DISTRO=debian-stable
+    - OCAML_VERSION=4.07 DISTRO=debian-stable
+    - OCAML_VERSION=4.07 DISTRO=alpine

--- a/test/mock_ioctl_linux.c
+++ b/test/mock_ioctl_linux.c
@@ -6,11 +6,18 @@
 #include <stdio.h>
 #include <sys/ioctl.h>
 
-typedef int (*ioctl_t)(int, unsigned long, char*);
+/* Work around differing ioctl signatures between alpine and debian */
+#ifdef __GLIBC__
+typedef unsigned long request_t;
+#else
+typedef int request_t;
+#endif
+
+typedef int (*ioctl_t)(int, request_t, char*);
 
 static ioctl_t real_ioctl = NULL;
 
-int ioctl(int fd, unsigned long request, ...)
+int ioctl(int fd, request_t request, ...)
 {
 	va_list ap;
 	va_start(ap, request);


### PR DESCRIPTION
Since the opam builds now test against alpine, we should probably support it.

Unfortunately the version of the c standard library that alpine uses differs from the one that debian uses (apparently glibc is not posix compliant). This MR fixes the issue and then adds an alpine CI build to validate it.