### PR TITLE
Fixup mac build (again)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,4 +12,5 @@ env:
     - OCAML_VERSION=4.05 DISTRO=debian-stable
     - OCAML_VERSION=4.06 DISTRO=debian-stable
     - OCAML_VERSION=4.07 DISTRO=debian-stable
-    - OCAML_VERSION=4.07 DISTRO=alpine
+    - OCAML_VERSION=4.08 DISTRO=debian-stable
+    - OCAML_VERSION=4.08 DISTRO=alpine

--- a/test/dune
+++ b/test/dune
@@ -20,12 +20,12 @@
 
 (rule
   (targets libmock_ioctl.dylib)
-  (enabled_if (= %{os_type} macosx))
+  (enabled_if (= %{system} macosx))
   (action (run %{cc} -dynamiclib -o %{targets} %{dep:mock_ioctl_mac.c}))
 )
 
 (rule
   (targets libmock_ioctl.dylib)
-  (enabled_if (<> %{os_type} macosx))
+  (enabled_if (<> %{system} macosx))
   (action (write-file %{targets} ""))
 )

--- a/test/mock_ioctl_linux.c
+++ b/test/mock_ioctl_linux.c
@@ -6,8 +6,9 @@
 #include <stdio.h>
 #include <sys/ioctl.h>
 
-/* Work around differing ioctl signatures between alpine and debian */
-#ifdef __GLIBC__
+/* Work around differing ioctl signatures between muscl (alpine), */
+/* glibc (debian) and libsystem (mac)                             */
+#if defined(__GLIBC__) || defined(__APPLE__)
 typedef unsigned long request_t;
 #else
 typedef int request_t;


### PR DESCRIPTION
It would really be easier if we had mac in CI, but to be honest I doubt we will make many modifications to this package in the future.

I've also added a 4.08 build for debian, and switched the alpine one to use that as well - I don't think it is worth covering the full matrix.