### PR TITLE
Add compatibility with Windows

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,6 +12,7 @@ jobs:
         os:
           - macos-latest
           - ubuntu-latest
+          - windows-latest
         ocaml-compiler:
           - 4.13.x
           - 4.08.x

--- a/src/terminal_size_stubs.c
+++ b/src/terminal_size_stubs.c
@@ -1,22 +1,64 @@
 #include <caml/alloc.h>
 #include <caml/memory.h>
 #include <caml/mlvalues.h>
+
+struct dimensions {
+    int ok;
+    int rows;
+    int columns;
+};
+
+#ifdef _WIN32
+#include <windows.h>
+
+struct dimensions get_dimensions() {
+    CONSOLE_SCREEN_BUFFER_INFO info;
+
+    int success = GetConsoleScreenBufferInfo(GetStdHandle(STD_OUTPUT_HANDLE), &info);
+
+    if (!success) {
+        return (struct dimensions) {.ok = 0, .rows = 0, .columns = 0};
+    }
+
+    // Inspired from https://stackoverflow.com/questions/6812224/getting-terminal-size-in-c-for-windows.
+    return (struct dimensions) {
+        .ok = 1,
+        .rows = info.srWindow.Bottom - info.srWindow.Top + 1,
+        .columns = info.srWindow.Right - info.srWindow.Left + 1,
+    };
+}
+#else
 #include <sys/ioctl.h>
 #include <unistd.h>
+
+struct dimensions get_dimensions() {
+	struct winsize ws;
+
+	int z = ioctl(STDOUT_FILENO, TIOCGWINSZ, &ws);
+
+	if (!z) {
+        return (struct dimensions) {.ok = 1, .rows = ws.ws_row, .columns = ws.ws_col};
+    }
+
+    return (struct dimensions) {.ok = 0, .rows = 0, .columns = 0};
+}
+#endif
 
 CAMLprim value ocaml_terminal_size_get(value unit) {
 	CAMLparam1(unit);
 	CAMLlocal2(result, pair);
-	struct winsize ws;
-	int z = ioctl(STDOUT_FILENO, TIOCGWINSZ, &ws);
-	if(z == 0) {
+
+    struct dimensions dimensions = get_dimensions();
+
+    if (dimensions.ok) {
 		result = caml_alloc(1, 0);
 		pair = caml_alloc(2, 0);
 		Store_field(result, 0, pair);
-		Store_field(pair, 0, Val_int(ws.ws_row));
-		Store_field(pair, 1, Val_int(ws.ws_col));
-	} else {
-		result = Val_int(0);
-	}
+		Store_field(pair, 0, Val_int(dimensions.rows));
+		Store_field(pair, 1, Val_int(dimensions.columns));
+    } else {
+        result = Val_int(0);
+    }
+
 	CAMLreturn (result);
 }

--- a/test/dune
+++ b/test/dune
@@ -1,5 +1,6 @@
 (test
   (name testsuite)
+  (enabled_if (= %{os_type} Unix))
   (libraries
     alcotest
     terminal_size
@@ -15,6 +16,7 @@
 
 (rule
   (targets dllmock_ioctl.so)
+  (enabled_if (= %{os_type} Unix))
   (action (run %{cc} -shared -o %{targets} %{dep:mock_ioctl_linux.c}))
 )
 


### PR DESCRIPTION
For now tests are disabled on Windows because I haven't found an easy
way to mock the Windows API calls.

I have checked that the right values are returned on Windows 10, in
cmd.exe, PowerShell and Windows Terminal. In Cygwin, unfortunately,
`None` is returned.